### PR TITLE
Update the FluentValidation fail-fast comparison.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -398,7 +398,7 @@ Again, no rule predicate is triggered. Also, null `LastName` member doesn't resu
 
 ### Validot's Validator is immutable
 
-Once [validator](../docs/DOCUMENTATION.md#validator) instance is created, you can't modify its internal state or [settings](../docs/DOCUMENTATION.md#settings). If you need the process to fail fast (FluentValidation's `CascadeMode.StopOnFirstFailure`), use the flag:
+Once [validator](../docs/DOCUMENTATION.md#validator) instance is created, you can't modify its internal state or [settings](../docs/DOCUMENTATION.md#settings). If you need the process to fail fast (FluentValidation's `CascadeMode.Stop`), use the flag:
 
 ``` csharp
 validator.Validate(model, failFast: true);

--- a/tests/Validot.Benchmarks/Comparisons/ValidationBenchmark.cs
+++ b/tests/Validot.Benchmarks/Comparisons/ValidationBenchmark.cs
@@ -29,7 +29,7 @@ namespace Validot.Benchmarks.Comparisons
         [Benchmark]
         public bool IsValid_FluentValidation()
         {   
-            _fluentValidationValidator.CascadeMode = CascadeMode.StopOnFirstFailure;
+            _fluentValidationValidator.CascadeMode = CascadeMode.Stop;
             var models = _dataSets[DataSet];
             
             var t = true;
@@ -60,7 +60,7 @@ namespace Validot.Benchmarks.Comparisons
         [Benchmark]
         public object FailFast_FluentValidation()
         {
-            _fluentValidationValidator.CascadeMode = CascadeMode.StopOnFirstFailure;
+            _fluentValidationValidator.CascadeMode = CascadeMode.Stop;
             var models = _dataSets[DataSet];
 
             object t = null;

--- a/tests/Validot.Benchmarks/Validot.Benchmarks.csproj
+++ b/tests/Validot.Benchmarks/Validot.Benchmarks.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="FluentValidation" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi @bartoszlenar,

The "fail-fast" comparison with FV wasn't completely accurate as `StopOnFirstFailure` doesn't actually perform fail-fast at validator-level (only at rule-level). We added a true fail-fast option with the 9.1 release (see https://jeremyskinner.co.uk/2020/08/08/fluentvalidation-91-released/ for details), so thought I'd update your comparison too :) 