### PR TITLE
Add Portuguese translation

### DIFF
--- a/src/Validot/Translations/Portuguese/PortugueseTranslation.cs
+++ b/src/Validot/Translations/Portuguese/PortugueseTranslation.cs
@@ -1,0 +1,86 @@
+namespace Validot.Translations
+{
+    using System.Collections.Generic;
+
+    public static partial class Translation
+    {
+        public static IReadOnlyDictionary<string, string> Portuguese { get; } = new Dictionary<string, string>
+        {
+            [MessageKey.Global.Error] = "Erro",
+            [MessageKey.Global.Required] = "Obrigatório",
+            [MessageKey.Global.Forbidden] = "Proibido",
+            [MessageKey.Global.ReferenceLoop] = "(ciclo de referência)",
+
+            [MessageKey.BoolType.True] = "Deve ser verdadeiro",
+            [MessageKey.BoolType.False] = "Deve ser falso",
+
+            [MessageKey.CharType.EqualToIgnoreCase] = "Deve ser igual a {value} (ignorando maiúsculas e minúsculas)",
+            [MessageKey.CharType.NotEqualToIgnoreCase] = "Não deve ser igual a {value} (ignorando maiúsculas e minúsculas)",
+
+            [MessageKey.GuidType.EqualTo] = "Deve ser igual a {value}",
+            [MessageKey.GuidType.NotEqualTo] = "Não deve ser igual a {value}",
+            [MessageKey.GuidType.NotEmpty] = "Não deve ser só zeros",
+
+            [MessageKey.Collections.EmptyCollection] = "Deve estar vazio",
+            [MessageKey.Collections.NotEmptyCollection] = "Não deve estar vazio",
+            [MessageKey.Collections.ExactCollectionSize] = "Deve conter exatamente {size} elementos",
+            [MessageKey.Collections.MaxCollectionSize] = "Deve conter no máximo {size} elementos",
+            [MessageKey.Collections.MinCollectionSize] = "Deve conter no mínimo {size} elementos",
+            [MessageKey.Collections.CollectionSizeBetween] = "Deve conter entre {min} e {max} elementos",
+
+            [MessageKey.Numbers.EqualTo] = "Deve ser igual a  {value}",
+            [MessageKey.Numbers.NotEqualTo] = "Não deve ser igual a {value}",
+            [MessageKey.Numbers.GreaterThan] = "Deve ser maior que {min}",
+            [MessageKey.Numbers.GreaterThanOrEqualTo] = "Deve ser maior ou igual a {min}",
+            [MessageKey.Numbers.LessThan] = "Deve ser menor que {max}",
+            [MessageKey.Numbers.LessThanOrEqualTo] = "Deve ser menor ou igual a {max}",
+            [MessageKey.Numbers.Between] = "Deve estar entre {min} e {max} (exclusivo)",
+            [MessageKey.Numbers.BetweenOrEqualTo] = "Deve estar entre {min} e {max} (inclusive)",
+            [MessageKey.Numbers.NonZero] = "Não deve ser zero",
+            [MessageKey.Numbers.Positive] = "Deve ser positivo",
+            [MessageKey.Numbers.NonPositive] = "Não deve ser positivo",
+            [MessageKey.Numbers.Negative] = "Deve ser negativo",
+            [MessageKey.Numbers.NonNegative] = "Não deve ser negativo",
+            [MessageKey.Numbers.NonNaN] = "Não deve ser NaN",
+
+            [MessageKey.Texts.Email] = "Deve ser um endereço de email válido",
+            [MessageKey.Texts.EqualTo] = "Deve ser igual a {value}",
+            [MessageKey.Texts.NotEqualTo] = "Não deve ser igual a {value}",
+            [MessageKey.Texts.Contains] = "Deve conter {value}",
+            [MessageKey.Texts.NotContains] = "Não deve conter {value}",
+            [MessageKey.Texts.NotEmpty] = "Não deve estar vazio",
+            [MessageKey.Texts.NotWhiteSpace] = "Não deve consistir apenas em caracteres de espaço em branco",
+            [MessageKey.Texts.SingleLine] = "Deve consistir em uma única linha",
+            [MessageKey.Texts.ExactLength] = "Deve ter {length} caracteres",
+            [MessageKey.Texts.MaxLength] = "Deve ter no máximo {max} caracteres",
+            [MessageKey.Texts.MinLength] = "Deve ter no mínimo {min} caracteres",
+            [MessageKey.Texts.LengthBetween] = "Deve ter entre {min} e {max} caracteres",
+            [MessageKey.Texts.Matches] = "Deve corresponder ao padrão de expressão regular {pattern}",
+            [MessageKey.Texts.StartsWith] = "Deve começar com {value}",
+            [MessageKey.Texts.EndsWith] = "Deve terminar com {value}",
+
+            [MessageKey.Times.EqualTo] = "Deve ser igual a {value}",
+            [MessageKey.Times.NotEqualTo] = "Não deve ser igual a {value}",
+            [MessageKey.Times.After] = "Deve ser posterior a {value}",
+            [MessageKey.Times.AfterOrEqualTo] = "Deve ser igual ou posterior a {value}",
+            [MessageKey.Times.Before] = "Deve ser anterior a {value}",
+            [MessageKey.Times.BeforeOrEqualTo] = "Deve ser igual ou anterior a {value}",
+            [MessageKey.Times.Between] = "Deve estar entre {min} e {max} (exclusivo)",
+            [MessageKey.Times.BetweenOrEqualTo] = "Deve estar entre {min} e {max} (inclusive)",
+
+            [MessageKey.TimeSpanType.EqualTo] = "Deve ser igual a {value}",
+            [MessageKey.TimeSpanType.NotEqualTo] = "Não deve ser igual a {value}",
+            [MessageKey.TimeSpanType.GreaterThan] = "Deve ser maior que {value}",
+            [MessageKey.TimeSpanType.GreaterThanOrEqualTo] = "Deve ser maior ou igual que {value}",
+            [MessageKey.TimeSpanType.LessThan] = "Deve ser menor que {value}",
+            [MessageKey.TimeSpanType.LessThanOrEqualTo] = "Deve ser menor ou igual que {value}",
+            [MessageKey.TimeSpanType.Between] = "Deve estar entre {min} e {max} (exclusivo)",
+            [MessageKey.TimeSpanType.BetweenOrEqualTo] = "Deve estar entre {min} e {max} (inclusivo)",
+            [MessageKey.TimeSpanType.NonZero] = "Não deve ser zero",
+            [MessageKey.TimeSpanType.Positive] = "Deve ser positivo",
+            [MessageKey.TimeSpanType.NonPositive] = "Não deve ser positivo",
+            [MessageKey.TimeSpanType.Negative] = "Deve ser negativo",
+            [MessageKey.TimeSpanType.NonNegative] = "Não deve ser negativo"
+        };
+    }
+}

--- a/src/Validot/Translations/Portuguese/PortugueseTranslationsExtensions.cs
+++ b/src/Validot/Translations/Portuguese/PortugueseTranslationsExtensions.cs
@@ -1,0 +1,20 @@
+namespace Validot
+{
+    using Validot.Settings;
+    using Validot.Translations;
+
+    public static partial class TranslationsExtensions
+    {
+        /// <summary>
+        /// Adds Portuguese translation dictionary for the error messages used in the built-in rules.
+        /// </summary>
+        /// <param name="this">Settings fluent API builder - input.</param>
+        /// <returns>Settings fluent API builder - output.</returns>
+        public static ValidatorSettings WithPortugueseTranslation(this ValidatorSettings @this)
+        {
+            ThrowHelper.NullArgument(@this, nameof(@this));
+
+            return @this.WithTranslation(nameof(Translation.Portuguese), Translation.Portuguese);
+        }
+    }
+}

--- a/src/Validot/Translations/Spanish/SpanishTranslation.cs
+++ b/src/Validot/Translations/Spanish/SpanishTranslation.cs
@@ -64,7 +64,7 @@ namespace Validot.Translations
             [MessageKey.Times.After] = "Debe ser posterior a {value}",
             [MessageKey.Times.AfterOrEqualTo] = "Debe ser igual o posterior a {value}",
             [MessageKey.Times.Before] = "Debe ser anterior a {value}",
-            [MessageKey.Times.BeforeOrEqualTo] = "Debe ser anterior a {value}",
+            [MessageKey.Times.BeforeOrEqualTo] = "Debe ser igual o anterior a {value}",
             [MessageKey.Times.Between] = "Debe estar entre {min} y {max} (exclusivo)",
             [MessageKey.Times.BetweenOrEqualTo] = "Debe estar entre {min} y {max} (inclusive)",
 

--- a/tests/Validot.Tests.Unit/Translations/Portuguese/PortugueseTranslationsExtensionsTests.cs
+++ b/tests/Validot.Tests.Unit/Translations/Portuguese/PortugueseTranslationsExtensionsTests.cs
@@ -1,0 +1,34 @@
+namespace Validot.Tests.Unit.Translations.Portuguese
+{
+    using System.Linq;
+
+    using FluentAssertions;
+
+    using Validot.Settings;
+    using Validot.Translations;
+
+    using Xunit;
+
+    public class PortugueseTranslationsExtensionsTests
+    {
+        [Fact]
+        public void Portuguese_Should_HaveValues_NonNullNorEmptyNorWhiteSpace()
+        {
+            Translation.Portuguese.Values.All(m => !string.IsNullOrWhiteSpace(m)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Portuguese_Should_HaveValues_OnlyFromMessageKeys()
+        {
+            MessageKey.All.Should().Contain(Translation.Portuguese.Keys);
+        }
+
+        [Fact]
+        public void WithPortugueseTranslation_Should_AddTranslation()
+        {
+            var settings = new ValidatorSettings();
+            settings.WithPortugueseTranslation();
+            TranslationTestHelpers.ShouldContainSingleTranslation(settings.Translations, "Portuguese", Translation.Portuguese);
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Related issue: [#13](https://github.com/bartoszlenar/Validot/issues/13) (Add Portuguese translation)

## Type of changes
* [ ]  Documentation update or other changes not related to the code.
* [x]  Bug fix (non-breaking change which fixes an issue).
* [x]  New feature (non-breaking change which adds functionality).
* [ ]  Breaking change (fix or feature that would cause existing functionality to change).

## Description
* Created new folder `Portuguese` in `src\Validot\Translations`.
* Added two files `PortugueseTranslation.cs` and `PortugueseTranslationsExtensions.cs` in the new folder `Portuguese`.
* Fix Spanish translation

## Tests
* Added new test subclass in `TranslationTests.cs` for Portuguese translation testing.